### PR TITLE
Chore/docs env alignment 20260119

### DIFF
--- a/.github/workflows/verify-repo.yml
+++ b/.github/workflows/verify-repo.yml
@@ -12,16 +12,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Block runtime or indices tracking
+      - name: Block runtime state tracking (allow runtime code)
         run: |
           set -e
-          if git ls-files | grep -E '^(runtime/|indices/)' >/dev/null; then
-            echo "ERROR: runtime/ or indices/ paths are tracked in git, which violates repo invariants." >&2
-            echo "Tracked paths:" >&2
-            git ls-files | grep -E '^(runtime/|indices/)' >&2
+          # runtime is a tracked surface; state inside runtime/* is generated and must not be committed
+          if git ls-files | grep -E '^(indices/|runtime/(indices|runs|audit|proposals|closures)/|runtime/\.venv|runtime/\.venv_)' >/dev/null; then
+            echo "ERROR: tracked runtime state or indices detected (forbidden by repo invariants)." >&2
+            echo "Tracked paths (matches):" >&2
+            git ls-files | grep -E '^(indices/|runtime/(indices|runs|audit|proposals|closures)/|runtime/\.venv|runtime/\.venv_)' >&2
             exit 1
           fi
-          echo "OK: no runtime/ or indices/ paths tracked."
+          echo "OK: runtime code tracked; no runtime state or indices tracked."
 
       - name: Ensure governance docs exist
         run: |

--- a/docs/REPO_MIGRATION_VERIFICATION.md
+++ b/docs/REPO_MIGRATION_VERIFICATION.md
@@ -2,6 +2,7 @@
 
 This checklist validates that the clean repo works end‑to‑end **after** a
 copy migration (DRY_RUN=0). It does not modify the source repo.
+Authoritative environment setup: `documentation/system_overview/ENVIRONMENT.md`.
 
 ---
 

--- a/docs/REPO_MIGRATION_VERIFICATION.md
+++ b/docs/REPO_MIGRATION_VERIFICATION.md
@@ -7,13 +7,13 @@ copy migration (DRY_RUN=0). It does not modify the source repo.
 
 ## A) Preconditions (minimal)
 
-- **Python**: 3.x available (venv in `runtime/.venv` preferred)
+- **Python**: 3.11 in `runtime/.venv` (required for runtime + CrewAI)
 - **Node/npm**: installed for UI (`runtime/ui/`)
 - **Env (if using local models):**
   - `LITELLM_MODEL` (if required by your setup)
   - `OLLAMA_API_BASE` (if using Ollama)
 - **Ports:**
-  - API: `8000`
+  - API: `8010`
   - UI: `5173` (fallback `5174`)
 
 ---
@@ -27,20 +27,21 @@ ls runtime/src runtime/scripts runtime/ui runtime/indexer.py runtime/api_server.
 ls runtime/runs runtime/proposals runtime/closures runtime/canonical runtime/indices runtime/audit
 ```
 
-### 2) Run indexer + validate JSON
+### 2) Activate venv + run indexer + validate JSON
 ```
 cd /Users/vwvd/Millway/AI-folder/Crew-AI/mustika-rasa-clean/runtime
-python3 indexer.py
-python3 -m json.tool indices/run_index.json >/dev/null
-python3 -m json.tool indices/inbox_index.json >/dev/null
-python3 -m json.tool indices/proposal_index.json >/dev/null
-python3 -m json.tool indices/closure_index.json >/dev/null
+source .venv/bin/activate
+./scripts/reindex_runtime.sh
+python -m json.tool indices/run_index.json >/dev/null
+python -m json.tool indices/inbox_index.json >/dev/null
+python -m json.tool indices/proposal_index.json >/dev/null
+python -m json.tool indices/closure_index.json >/dev/null
 ```
 
 ### 3) Start API + verify endpoints
 ```
 cd /Users/vwvd/Millway/AI-folder/Crew-AI/mustika-rasa-clean/runtime
-python3 -m uvicorn api_server:app --host 127.0.0.1 --port 8010 --reload
+./scripts/dev_start_api.sh
 ```
 Then in a new terminal:
 ```
@@ -114,11 +115,11 @@ Manual checks:
 - `lsof -i :8010`
 - `lsof -i :5173`
 
-**Missing venv / uvicorn**
-- Activate venv or install deps in `runtime/.venv`.
+**Missing venv / CrewAI / uvicorn**
+- Recreate `runtime/.venv` (Python 3.11) and install `requirements-ui.txt` (includes CrewAI).
 
 **Missing indices**
-- Run `python3 indexer.py` and recheck `indices/*.json`.
+- Run `./scripts/reindex_runtime.sh` and recheck `indices/*.json`.
 
 **API errors**
 - Check `runtime/audit/api_actions.log` and API console output.

--- a/documentation/operator/RUNBOOK.md
+++ b/documentation/operator/RUNBOOK.md
@@ -9,15 +9,14 @@
 - `runtime/scripts/dev_start_ui.sh`
 
 Notes:
-- If `runtime/.venv` exists, activate it before running scripts.
-- Use `python3` if `python` is not available.
+- `runtime/.venv` (Python 3.11) is required for RunnerV2 + CrewAI; scripts enforce it.
 
 ## Run a new excerpt job (Runner v2)
 
 Template command:
 
 ```bash
-python3 runtime/scripts/mustika_run_excerpt.py \
+runtime/.venv/bin/python runtime/scripts/mustika_run_excerpt.py \
   --excerpt-id <excerpt_id> \
   --excerpt-source <path_to_source_text> \
   --excerpt-version <version_tag> \
@@ -32,7 +31,7 @@ Outputs will land in:
 
 CLI reindex (filesystem → indices):
 - `runtime/scripts/reindex_runtime.sh`
-- `python3 runtime/indexer.py --base-path runtime`
+- `runtime/.venv/bin/python runtime/indexer.py --base-path runtime`
 Generates:
 - `runtime/indices/page_sources_coverage_index.json`
 
@@ -45,7 +44,7 @@ Purpose:
 - Checks registry entries against alignment entries and reports run coverage per excerpt.
 
 Command:
-- `python3 runtime/scripts/validate_excerpt_coverage.py`
+- `runtime/.venv/bin/python runtime/scripts/validate_excerpt_coverage.py`
 
 Preconditions:
 - `documentation/system_overview/EXCERPT_REGISTRY.md` exists.
@@ -71,12 +70,11 @@ Non-goals:
   - If UI does not start on the default port, it will try the next available.
   - Stop existing processes with `runtime/scripts/dev_down.sh`.
 
-- `uvicorn` missing:
-  - Ensure the runtime venv is active or install dependencies.
-  - Use `python3 -m uvicorn` (scripts already do this).
+- `uvicorn` / `crewai` missing:
+  - Ensure `runtime/.venv` (Python 3.11) is active and dependencies installed.
 
-- `python` vs `python3`:
-  - Use `python3` explicitly to avoid PATH issues.
+- Stub mode:
+  - If `mustikarasa_agents` is missing, the pipeline returns a stub with remarks.
 
 - Logs:
   - Run logs: `runtime/runs/*/logs/run.log`
@@ -86,8 +84,8 @@ ADDED: See `documentation/system_overview/PROJECT_STATE_PACK.md` (DoD — Run lo
 ## Run output regression check
 
 Command:
-- `python3 runtime/scripts/regression_check_run_outputs.py <baseline_run_dir> <candidate_run_dir>`
-- `python3 runtime/scripts/regression_check_indices.py`
+- `runtime/.venv/bin/python runtime/scripts/regression_check_run_outputs.py <baseline_run_dir> <candidate_run_dir>`
+- `runtime/.venv/bin/python runtime/scripts/regression_check_indices.py`
 
 Output:
 - `runtime/audit/run_regression_<baseline_id>_vs_<candidate_id>.md`

--- a/documentation/operator/RUNBOOK.md
+++ b/documentation/operator/RUNBOOK.md
@@ -10,6 +10,7 @@
 
 Notes:
 - `runtime/.venv` (Python 3.11) is required for RunnerV2 + CrewAI; scripts enforce it.
+- Environment (authoritative): `documentation/system_overview/ENVIRONMENT.md`.
 
 ## Run a new excerpt job (Runner v2)
 

--- a/documentation/system_overview/DEV_WORKFLOW.md
+++ b/documentation/system_overview/DEV_WORKFLOW.md
@@ -5,6 +5,7 @@
 - `cd /path/to/repo`
 - `cd runtime && ./scripts/dev_up.sh`
 - open `http://localhost:5173` (or `http://localhost:5174` if 5173 is busy)
+- Environment (authoritative): `documentation/system_overview/ENVIRONMENT.md`
 
 ---
 

--- a/documentation/system_overview/DEV_WORKFLOW.md
+++ b/documentation/system_overview/DEV_WORKFLOW.md
@@ -11,7 +11,7 @@
 ## Vereisten
 
 - macOS
-- Python 3 + `.venv` aanwezig
+- Python 3.11 + `runtime/.venv` (required for CrewAI)
 - Node.js + npm
 - (optioneel) Ollama lokaal voor LLM-tests
 
@@ -33,7 +33,7 @@ Dit start:
 - `./scripts/dev_down.sh`
 
 Dit stopt de processen op poorten:
-- `8000` (API)
+- `8010` (API)
 - `5173` of `5174` (UI)
 
 ---

--- a/documentation/system_overview/DEV_WORKFLOW.md
+++ b/documentation/system_overview/DEV_WORKFLOW.md
@@ -3,7 +3,7 @@
 ## TL;DR
 
 - `cd /path/to/repo`
-- `./scripts/dev_up.sh`
+- `cd runtime && ./scripts/dev_up.sh`
 - open `http://localhost:5173` (or `http://localhost:5174` if 5173 is busy)
 
 ---
@@ -19,7 +19,7 @@
 
 ## Start
 
-- `./scripts/dev_up.sh`
+- `cd runtime && ./scripts/dev_up.sh`
 
 Dit start:
 - backend (`uvicorn api_server:app` op `127.0.0.1:8010`)
@@ -30,7 +30,7 @@ Dit start:
 
 ## Stop
 
-- `./scripts/dev_down.sh`
+- `cd runtime && ./scripts/dev_down.sh`
 
 Dit stopt de processen op poorten:
 - `8010` (API)
@@ -58,5 +58,5 @@ Logs:
 
 ## Veelvoorkomende problemen
 
-- **/health 404** → je draait de verkeerde server → `./scripts/dev_down.sh` + `./scripts/dev_up.sh`
-- **/inbox 500** → run `./scripts/dev_up.sh` (reindex) + check `audit/api_server.log`
+- **/health 404** → je draait de verkeerde server → `cd runtime && ./scripts/dev_down.sh` + `cd runtime && ./scripts/dev_up.sh`
+- **/inbox 500** → run `cd runtime && ./scripts/dev_up.sh` (reindex) + check `audit/api_server.log`

--- a/documentation/system_overview/ENVIRONMENT.md
+++ b/documentation/system_overview/ENVIRONMENT.md
@@ -1,0 +1,53 @@
+# ENVIRONMENT — Local Runtime Setup (authoritative)
+
+This document is the source of truth for local dev/runtime environment setup.
+
+## Mac (Apple Silicon) — quick setup
+
+```bash
+cd runtime
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements-ui.txt
+cd ui
+npm install
+```
+
+## Run / stop (canonical)
+
+```bash
+cd runtime && ./scripts/dev_up.sh
+cd runtime && ./scripts/dev_down.sh
+```
+
+## Health checks
+
+```bash
+curl http://127.0.0.1:8010/health
+curl http://127.0.0.1:8010/inbox
+```
+
+## Required environment variables
+
+- `OPENAI_API_KEY` (required for OpenAI-compatible backends)
+- `OPENAI_MODEL` or `LITELLM_MODEL` (model selection)
+- Optional: `OPENAI_BASE_URL` or `LITELLM_BASE_URL` (local gateway)
+
+## Repo invariants (CI enforced)
+
+- `runtime/` code is tracked
+- State directories are generated and must not be committed:
+  - `runtime/indices/`
+  - `runtime/runs/`
+  - `runtime/audit/`
+  - `runtime/proposals/`
+  - `runtime/closures/`
+  - `runtime/.venv*`
+  - top-level `indices/`
+
+## Troubleshooting
+
+- No active venv → `source runtime/.venv/bin/activate`
+- `crewai` missing → `pip install -r runtime/requirements-ui.txt`
+- Wrong Python version → recreate venv with Python 3.11

--- a/documentation/system_overview/INVENTORY.md
+++ b/documentation/system_overview/INVENTORY.md
@@ -143,12 +143,12 @@ Top-level directories (excluding build artifacts):
 ## 4. Executables / Entry Points
 
 - `scripts/mustika_run_excerpt.py`
-  - Start: `python3 scripts/mustika_run_excerpt.py --excerpt-id ... --excerpt-source ... --excerpt-version ... --english ... --rough-nl ...`
+  - Start: `runtime/.venv/bin/python scripts/mustika_run_excerpt.py --excerpt-id ... --excerpt-source ... --excerpt-version ... --english ... --rough-nl ...`
   - Writes: `runs/<excerpt_id>/<RUN_...>/` (inputs, outputs, logs, eval, manifest)
   - Reads: input files (`--english`, `--rough-nl`)
 
 - `indexer.py`
-  - Start: `python3 indexer.py`
+  - Start: `runtime/.venv/bin/python indexer.py`
   - Writes: `indices/run_index.json`, `indices/inbox_index.json`, `indices/proposal_index.json`, `indices/closure_index.json`
   - Reads: `runs/`, `proposals/`, `closures/` (and `sandbox/phase8_runs`, `sandbox/phase9_runs` via adapter)
 

--- a/documentation/system_overview/MASTERPLAN_BIG_ROCKS.md
+++ b/documentation/system_overview/MASTERPLAN_BIG_ROCKS.md
@@ -370,3 +370,33 @@ Runbooks, troubleshooting, env checks.
 - 2026-01-20 — MASTERPLAN_BIG_ROCKS.md updated to fact-first masterplan with blockers, contracts, and patch plan. (evidence: `documentation/system_overview/MASTERPLAN_BIG_ROCKS.md`)
 - 2026-01-20 — CI workflow allows runtime, forbids runtime state; API host canon 127.0.0.1; QA scripts no snapshot. (evidence: `.github/workflows/verify-repo.yml`, `runtime/scripts/dev_start_api.sh`, `runtime/scripts/qa_suite_x.sh`, `runtime/scripts/qa_verify_inbox.sh`, `documentation/system_overview/DEV_WORKFLOW.md`)
 - 2026-01-20 — Scope correction: reverted unintended edits to runner/pipeline files back to HEAD; Phase 1 fixes remain limited to workflow + scripts + docs.
+
+### Session Closeout — 2026-01-20
+Done:
+- [x] CI invariant updated: workflow allows tracked `runtime/` while forbidding tracked runtime state (`runtime/{indices,runs,audit,proposals,closures}/`, `runtime/.venv*`) and top-level `indices/`, with explicit match reporting.
+- [x] Canonical API host/port aligned to `127.0.0.1:8010` in `runtime/scripts/dev_start_api.sh` and documented in `documentation/system_overview/DEV_WORKFLOW.md`.
+- [x] QA scripts re-pointed to active `runtime/` via script-derived root (removed frozen snapshot paths; guards added).
+- [x] `documentation/system_overview/issues/` now tracked with README + evidence notes.
+Next:
+- [x] Venv + deps single source-of-truth doc (Fase 1 remaining).
+- [ ] Pipeline boundary cleanup (runner imports test module) (Phase 2/3 prep).
+Blockers:
+- None known inside `mustika-rasa-clean` (verify CI green after push).
+Evidence:
+- Commit `1d06a4e`
+- `.github/workflows/verify-repo.yml`
+- `runtime/scripts/dev_start_api.sh`
+- `runtime/scripts/qa_suite_x.sh`
+- `runtime/scripts/qa_verify_inbox.sh`
+- `documentation/system_overview/DEV_WORKFLOW.md`
+- `documentation/system_overview/MASTERPLAN_BIG_ROCKS.md`
+- `documentation/system_overview/issues/README.md`
+- `documentation/system_overview/issues/20260120_runtime_pipeline_status.md`
+- `documentation/system_overview/issues/ENV_VENV_CREWAI_MISMATCH.md`
+- `documentation/system_overview/ENVIRONMENT.md`
+- `documentation/system_overview/DEV_WORKFLOW.md`
+- `documentation/operator/RUNBOOK.md`
+- `docs/REPO_MIGRATION_VERIFICATION.md`
+- `runtime/README_UI.md`
+- `documentation/system_overview/issues/ENV_VENV_CREWAI_MISMATCH.md`
+- `runtime/requirements-ui.txt`

--- a/documentation/system_overview/MASTERPLAN_BIG_ROCKS.md
+++ b/documentation/system_overview/MASTERPLAN_BIG_ROCKS.md
@@ -1,0 +1,372 @@
+# MASTERPLAN — Mustika Rasa Clean (Big Rocks)
+
+## 0) Status / Blockers (nu)
+
+1) **CI-invariant breach: runtime/ tracked but workflow blocks runtime/**
+   - Impact: CI faalt op elke push; repository kan niet groen worden.
+   - Evidence: `.github/workflows/verify-repo.yml` (blokkeert runtime/); runtime is tracked (e.g. `runtime/api_server.py`).
+   - Owner-action: beslis of runtime/ wél een tracked surface mag zijn of workflow moet worden aangepast.
+
+2) **API host mismatch (IPv6 vs IPv4) → health checks inconsistent**
+   - Impact: `/health` via `127.0.0.1` kan falen als API op `::1` bindt; QA scripts en docs zijn inconsistent.
+   - Evidence: `runtime/scripts/dev_start_api.sh` (host `::1`), `runtime/scripts/qa_full_system.sh` (curl `127.0.0.1:8010`).
+   - Owner-action: kies canonical host/port en update scripts + docs.
+
+3) **QA scripts wijzen naar frozen snapshot i.p.v. runtime**
+   - Impact: QA meet niet de actieve runtime; regressies blijven onzichtbaar.
+   - Evidence: `runtime/scripts/qa_suite_x.sh` + `runtime/scripts/qa_verify_inbox.sh` (RUNTIME_ROOT = cursor snapshot).
+   - Owner-action: herpoint QA naar `runtime/` of expliciet frozen-snapshot regime vastleggen.
+
+## 1) Doel en werkwijze
+
+- Scope: runtime-first stabilisatie van `runtime/` (runner, indexer, API, UI, QA) + minimale docs-alignment. (evidence: `runtime/` tree)
+- Non-goals: geen nieuwe productfeatures, geen inhoudelijke policy-wijzigingen buiten bestaande docs. (evidence: `docs/REPO_FREEZE.md`)
+- Fact-first: alleen claims met evidence; onzekerheden labelen als `FACT REQUEST` of `UNKNOWN`.
+- Filesystem-first: `runs/`, `proposals/`, `closures/` zijn leidend; `indices/` is afgeleid. (evidence: `runtime/indexer.py`)
+- Eerst masterplan dan cleanup: fasen + acceptance criteria bepalen, daarna pas opruimen/stabiliseren.
+
+## 2) Architectuurkaart (as-is)
+
+### 2.1 Entrypoints (runtime-first)
+
+- `runtime/scripts/mustika_run_excerpt.py` — CLI entrypoint voor RunnerV2 (start run bundle). (evidence: `runtime/scripts/mustika_run_excerpt.py`)
+- `runtime/src/runner_v2/runner.py` — RunnerV2 core: maakt run bundle + outputs + validator call. (evidence: `runtime/src/runner_v2/runner.py`)
+- `runtime/indexer.py` — filesystem scan → `indices/*.json`. (evidence: `runtime/indexer.py`)
+- `runtime/api_server.py` — FastAPI API voor inbox/runs/proposals/closures. (evidence: `runtime/api_server.py`)
+- `runtime/ui/` — Vite UI (via proxy `/api` → API). (evidence: `runtime/ui/vite.config.ts`)
+- `runtime/scripts/qa_full_system.sh` — end-to-end smoke checks API/indexer/UI. (evidence: `runtime/scripts/qa_full_system.sh`)
+- `runtime/scripts/dev_up.sh` — start API + reindex + UI. (evidence: `runtime/scripts/dev_up.sh`)
+
+### 2.2 Dataflow (filesystem-first)
+
+- Input → Runner → Pipeline → Outputs → Validator → Indices → API → UI → Human Review → Proposals/Closures.
+- Run bundle layout (RunnerV2): `runs/<excerpt_id>/<RUN_...>/` met `inputs/`, `outputs/`, `logs/`, `eval/`, `manifest.json`. (evidence: `runtime/src/runner_v2/runner.py`)
+
+### 2.3 Artefacts & directories
+
+- `runs/` — run bundles (immutable). (evidence: `runtime/src/runner_v2/runner.py`)
+- `indices/` — derived JSON indices. (evidence: `runtime/indexer.py`)
+- `proposals/` — proposal records; status update via API closures. (evidence: `runtime/api_server.py`)
+- `closures/` — closure records; immutable. (evidence: `runtime/api_server.py`)
+- `audit/` — logs (API + dev scripts). (evidence: `runtime/scripts/dev_start_api.sh`)
+- `canonical/` — conceptueel genoemd, maar directory ontbreekt. (UNKNOWN; evidence: `runtime/api_server.py`, `MISSING: runtime/canonical`)
+
+## 3) System contract (as-is)
+
+### 3.1 Input contract
+
+- RunnerV2 verwacht `--excerpt-id`, `--excerpt-source`, `--excerpt-version`, `--english`, `--rough-nl`. (evidence: `runtime/scripts/mustika_run_excerpt.py`)
+- Input files bestaan en zijn UTF-8 leesbaar. (evidence: `runtime/scripts/mustika_run_excerpt.py`)
+- Inputs worden gekopieerd naar `runs/<excerpt_id>/<RUN_...>/inputs/`. (evidence: `runtime/src/runner_v2/runner.py`)
+
+### 3.2 Pipeline contract
+
+- Pipeline entry: `runtime/test_multi_agent_fidelity.py::run_pipeline`. (evidence: `runtime/src/runner_v2/runner.py`)
+- Fases: Translation Quality → Readability → Fidelity. (evidence: `runtime/test_multi_agent_fidelity.py`)
+- Agent builder: `runtime/src/mustikarasa_agents.py::build_agents`. (evidence: `runtime/src/mustikarasa_agents.py`)
+- Stub mode wanneer CrewAI/agents ontbreken; returnt rough_nl + remarks. (evidence: `runtime/test_multi_agent_fidelity.py`)
+
+### 3.3 Output contract
+
+- Outputs (minimaal): `outputs/annotator_primary.json`, `outputs/challenger_primary.json`, `outputs/crew_provisional.json`, `outputs/final.txt`. (evidence: `runtime/src/runner_v2/runner.py`)
+- Eval: `eval/output_contract_checks.txt` (validator output). (evidence: `runtime/src/runner_v2/runner.py`)
+- Logs + manifest: `logs/run.log`, `manifest.json`, `command.txt`, `env_allowlist.txt`. (evidence: `runtime/src/runner_v2/runner.py`)
+
+### 3.4 Index contract
+
+- `indexer.py` genereert `indices/run_index.json`, `proposal_index.json`, `closure_index.json`, `inbox_index.json`. (evidence: `runtime/indexer.py`)
+- Inbox regels: validator FAIL → incident; blocking gate → gate; challenger issues → review_required; proposal open → review_required; required_closure → closure_needed (met closure lookup guard). (evidence: `runtime/indexer.py`)
+- Indexer ondersteunt meerdere layouts via adapter. (evidence: `runtime/indexer.py`, `runtime/src/runner_v2/run_layout_adapter.py`)
+
+### 3.5 API contract
+
+- `GET /health`, `GET /version`, `POST /reindex`. (evidence: `runtime/api_server.py`)
+- `GET /inbox`, `GET /runs/{run_id}`, `GET /proposals/{proposal_id}`, `GET /closures/{closure_id}`. (evidence: `runtime/api_server.py`)
+- `POST /closures` schrijft closure + update proposal status. (evidence: `runtime/api_server.py`)
+
+### 3.6 UI contract
+
+- Vite proxy `/api` → `http://localhost:8010`. (evidence: `runtime/ui/vite.config.ts`)
+- UI leest uitsluitend via API; geen direct filesystem access. (evidence: `runtime/ui/src/api.ts`)
+
+## 4) Current Reality: divergences / risico’s (fact-first)
+
+1) **CI invariant breach: runtime/ tracked vs workflow block**
+   - Impact: CI fail op elke push.
+   - Evidence: `.github/workflows/verify-repo.yml` + tracked runtime files (`runtime/api_server.py`).
+   - Next decision / fix target: workflow aanpassen of runtime/ uit git halen.
+
+2) **IPv6 vs IPv4 mismatch in API host**
+   - Impact: health checks/QA kunnen falen afhankelijk van resolver.
+   - Evidence: `runtime/scripts/dev_start_api.sh` (`--host ::1`), `runtime/scripts/qa_full_system.sh` (curl `127.0.0.1`).
+   - Next decision / fix target: canonical host bepalen en harmoniseren.
+
+3) **Docs command path mismatch (DEV_WORKFLOW vs runtime/scripts)**
+   - Impact: operators draaien verkeerde commands vanuit verkeerde cwd.
+   - Evidence: `documentation/system_overview/DEV_WORKFLOW.md` (uses `./scripts/dev_up.sh`), scripts bevinden zich onder `runtime/scripts/`.
+   - Next decision / fix target: DEV_WORKFLOW expliciet maken als source-of-truth en correct pad beschrijven.
+
+4) **Validator is minimal + gate semantics beperkt**
+   - Impact: validator detecteert nauwelijks kwaliteitsissues; gates kunnen false positives/negatives geven.
+   - Evidence: `sandbox/tools/phase8_output_contract_validator.sh` (enkel check op “definitieve”).
+   - Next decision / fix target: contract uitbreiden of validator scope documenteren.
+
+5) **Pipeline import boundary: runner importeert test module**
+   - Impact: “test” module wordt productie-pipeline; risico op drift.
+   - Evidence: `runtime/src/runner_v2/runner.py` import `test_multi_agent_fidelity`.
+   - Next decision / fix target: pipeline module verplaatsen naar runtime/src of expliciet markeren.
+
+6) **Duplicate sys.path inserts in indexer**
+   - Impact: onnodige side-effects, onduidelijke import chain.
+   - Evidence: `runtime/indexer.py` (meerdere BASE_DIR/sys.path insert blokken).
+   - Next decision / fix target: single insertion, duidelijke comment.
+
+7) **QA scripts target frozen snapshot**
+   - Impact: QA tests lopen niet tegen runtime; regressies onzichtbaar.
+   - Evidence: `runtime/scripts/qa_suite_x.sh`, `runtime/scripts/qa_verify_inbox.sh` (RUNTIME_ROOT naar cursor snapshot).
+   - Next decision / fix target: RUNTIME_ROOT → `runtime/` of expliciete “frozen snapshot QA” policy.
+
+## 5) Big Rocks Roadmap (6 fases)
+
+### Fase 1 — Stabilisatie
+
+**Doel**
+Runtime moet met 1 command starten en indexeren zonder handmatige fixes.
+
+**Scope**
+Scripts, venv, ports, basic smoke tests.
+
+**Deliverables**
+- Dev/QA scripts consistent met runtime/.venv
+- Port/host eenduidig
+- Basic health checks groen
+
+**To-do checklist**
+- [x] Harmoniseer API host/port in scripts + docs (localhost/127.0.0.1/::1). (evidence: `runtime/scripts/dev_start_api.sh`, `runtime/scripts/qa_full_system.sh`)
+- [x] QA scripts herpointen naar runtime (geen frozen snapshot). (evidence: `runtime/scripts/qa_suite_x.sh`, `runtime/scripts/qa_verify_inbox.sh`)
+- [ ] Venv + deps vastleggen in single source-of-truth doc. (evidence: `documentation/system_overview/DEV_WORKFLOW.md`)
+- [x] CI invariant oplossen (runtime tracked vs workflow). (evidence: `.github/workflows/verify-repo.yml`)
+- [ ] `runtime/canonical/` directory status beslissen (maken of policy aanpassen). (UNKNOWN)
+
+**Done means**
+- `cd runtime && ./scripts/dev_up.sh` → `/health` = 200 en UI opent. (evidence: `runtime/scripts/dev_up.sh`)
+- `cd runtime && ./scripts/qa_full_system.sh` green. (evidence: `runtime/scripts/qa_full_system.sh`)
+- CI workflow passeert zonder runtime conflict. (evidence: `.github/workflows/verify-repo.yml`)
+
+### Fase 2 — Productkwaliteit (output discipline + editorial)
+
+**Doel**
+Pipeline output voldoet aan output discipline (NL-only, no meta), validator consistent.
+
+**Scope**
+Pipeline prompts, validator, output files.
+
+**Deliverables**
+- Strakke prompt constraints
+- Validator rules aligned met output contract
+
+**To-do checklist**
+- [ ] Versterk output discipline in pipeline prompts. (evidence: `runtime/test_multi_agent_fidelity.py`)
+- [ ] Documenteer validator scope (wat is “PASS/FAIL”). (evidence: `sandbox/tools/phase8_output_contract_validator.sh`)
+- [ ] Check “final.txt” is always produced. (evidence: `runtime/src/runner_v2/runner.py`)
+- [ ] Define “remarks” format policy (consistent with UI). (evidence: `runtime/src/runner_v2/runner.py`)
+
+**Done means**
+- Pipeline output is 100% NL and one-block (manual smoke). (evidence: `runtime/test_multi_agent_fidelity.py`)
+- `output_contract_checks.txt` exists for each run. (evidence: `runtime/src/runner_v2/runner.py`)
+
+### Fase 3 — Integratie (indices/API/UI)
+
+**Doel**
+Indices, API en UI tonen consistente status en data.
+
+**Scope**
+Indexer, API endpoints, UI data mapping.
+
+**Deliverables**
+- Inbox rules stable
+- UI shows proposal_md, run detail, closure creation
+
+**To-do checklist**
+- [ ] Verify proposal/closure inbox rules (no closure_needed for closed). (evidence: `runtime/indexer.py`)
+- [ ] UI contract check: `proposal_md` mapping in UI. (evidence: `runtime/api_server.py`, `runtime/ui/src/components/ReviewPackViewer.tsx`)
+- [ ] Verify API `/reindex` uses correct base_path. (evidence: `runtime/api_server.py`)
+- [ ] Ensure indices deterministic across two runs. (evidence: `runtime/indexer.py`)
+- [ ] Document run layout adapter behavior. (evidence: `runtime/src/runner_v2/run_layout_adapter.py`)
+
+**Done means**
+- UI shows proposal content for existing `proposal.md`. (evidence: `runtime/api_server.py`, `runtime/ui/src`)
+- `indices/inbox_index.json` matches rules. (evidence: `runtime/indexer.py`)
+
+### Fase 4 — Governance (canonical + human gate)
+
+**Doel**
+Human gate + closure rules consistent met policy.
+
+**Scope**
+Policy docs in monorepo vs runtime, stub-mode signals.
+
+**Deliverables**
+- Canon policy pointers
+- Human gate checklists
+
+**To-do checklist**
+- [ ] Policy pointers consolidated to canonical docs. (evidence: `docs/OPERATOR_ENTRYPOINT.md` pointer)
+- [ ] Human gate checklist visible in runtime docs. (evidence: `documentation/system_overview/GOVERNANCE.md`)
+- [ ] Explicit stub-mode note (CrewAI missing) in runbook. (evidence: `runtime/test_multi_agent_fidelity.py`)
+
+**Done means**
+- Operator can find canonical gate rules in 1 hop. (evidence: doc link)
+- No conflicting status/gate definitions. (FACT REQUEST)
+
+### Fase 5 — QA/CI/Release gates
+
+**Doel**
+Repeatable QA and CI checks for minimal regressies.
+
+**Scope**
+qa_full_system.sh, qa_suite_x.sh, CI invariants.
+
+**Deliverables**
+- CI-friendly smoke tests
+- Runtime state excluded from git
+
+**To-do checklist**
+- [ ] CI rule: runtime state ignored or workflow updated. (evidence: `.github/workflows/verify-repo.yml`)
+- [ ] QA suite produces deterministic audit logs. (evidence: `runtime/scripts/qa_full_system.sh`)
+- [ ] L0/L1 checks in Suite X align with runtime path. (evidence: `runtime/scripts/qa_suite_x.sh`)
+- [ ] Ensure `sandbox/tools` scripts are tracked (ignore rules). (evidence: `.gitignore`, `sandbox/tools/*.sh`)
+
+**Done means**
+- CI passes on main. (FACT REQUEST)
+- `audit/qa/latest/summary.tsv` generated for QA run. (evidence: `runtime/scripts/qa_full_system.sh`)
+
+### Fase 6 — Ops & Sustainability (local-first)
+
+**Doel**
+Local ops are reliable, repeatable, documented.
+
+**Scope**
+Runbooks, troubleshooting, env checks.
+
+**Deliverables**
+- Runbook with minimal steps
+- Troubleshooting checklist
+
+**To-do checklist**
+- [ ] Single source-of-truth runbook (dev up + QA). (evidence: `documentation/system_overview/DEV_WORKFLOW.md`)
+- [ ] Troubleshooting matrix (ports, venv, API). (evidence: `documentation/system_overview/RUNBOOK_TROUBLESHOOTING.md`)
+- [ ] Clarify Python version + CrewAI dependency in runbook. (evidence: `runtime/requirements-ui.txt`)
+
+**Done means**
+- New operator can start system in <10 min. (FACT REQUEST)
+- Fewer than 3 manual steps after `dev_up.sh`. (FACT REQUEST)
+
+## 6) Patch Plan (exact files, nog niet toepassen)
+
+- File: `.github/workflows/verify-repo.yml`
+  - Edit intent: reconcile invariant with tracked runtime/ (either allow runtime or move runtime out of git).
+  - Risk: CI could ignore necessary checks if too broad.
+  - Rollback: revert workflow.
+
+- File: `runtime/scripts/dev_start_api.sh`
+  - Edit intent: canonical host/port (choose localhost/127.0.0.1/::1) + healthcheck consistent with QA.
+  - Risk: local bind issues on macOS.
+  - Rollback: revert file.
+
+- File: `runtime/scripts/mustika_run_excerpt.py`
+  - Edit intent: explicit venv enforcement + PYTHONPATH, no PATH python fallback.
+  - Risk: breaking CLI usage if venv missing.
+  - Rollback: revert file.
+
+- File: `runtime/src/runner_v2/runner.py`
+  - Edit intent: move pipeline import to a non-test module; clarify validator behavior.
+  - Risk: pipeline break if module path changes.
+  - Rollback: revert file.
+
+- File: `runtime/indexer.py`
+  - Edit intent: remove duplicate sys.path inserts; clean import block.
+  - Risk: import errors if refactor is wrong.
+  - Rollback: revert file.
+
+- File: `runtime/api_server.py`
+  - Edit intent: clarify contract surfaces; ensure closure schema stable.
+  - Risk: API response shape changes.
+  - Rollback: revert file.
+
+- File: `documentation/system_overview/DEV_WORKFLOW.md`
+  - Edit intent: make it single source for dev commands and ports; link other docs to it.
+  - Risk: doc drift if other docs not aligned.
+  - Rollback: revert file.
+
+## 7) Golden Path (1-command)
+
+**Dev up**
+- `cd runtime && ./scripts/dev_up.sh` (evidence: `runtime/scripts/dev_up.sh`)
+
+**QA full system**
+- `cd runtime && ./scripts/qa_full_system.sh` (evidence: `runtime/scripts/qa_full_system.sh`)
+
+**Expected ports/logs**
+- API: `http://localhost:8010/health` (evidence: `runtime/ui/vite.config.ts`, `runtime/scripts/qa_full_system.sh`)
+- UI: `http://localhost:5173` (evidence: `runtime/scripts/dev_start_ui.sh`)
+- Logs: `runtime/audit/api_server.log`, `runtime/audit/ui_dev.log` (evidence: `runtime/scripts/dev_start_api.sh`, `runtime/scripts/dev_start_ui.sh`)
+
+**Troubleshooting (6 bullets)**
+- Venv missing → `source runtime/.venv/bin/activate`. (evidence: `runtime/scripts/dev_start_api.sh`)
+- API not reachable → check `runtime/audit/api_server.log`. (evidence: `runtime/scripts/dev_start_api.sh`)
+- Port conflict → `lsof -i :8010` and `lsof -i :5173`. (evidence: `runtime/scripts/dev_up.sh`)
+- UI not loading → check `runtime/audit/ui_dev.log`. (evidence: `runtime/scripts/dev_start_ui.sh`)
+- Inbox empty → run `./scripts/reindex_runtime.sh`. (evidence: `runtime/scripts/reindex_runtime.sh`)
+- QA fails on CrewAI → verify venv + `crewai` installed. (evidence: `runtime/requirements-ui.txt`)
+
+### Weekly Operator Checklist (10 min)
+
+- [ ] `/health` returns 200 (API). (evidence: `runtime/api_server.py`)
+- [ ] Run `./scripts/reindex_runtime.sh`. (evidence: `runtime/scripts/reindex_runtime.sh`)
+- [ ] `/inbox` loads and items look plausible (non-empty if work is pending). (evidence: `runtime/api_server.py`)
+- [ ] `audit/` log size sane (no runaway). (evidence: `runtime/scripts/dev_start_api.sh`)
+- [ ] `npm run build` in `runtime/ui/` succeeds. (evidence: `runtime/scripts/qa_full_system.sh`)
+- [ ] Run bundle created for a test excerpt (optional). (evidence: `runtime/scripts/mustika_run_excerpt.py`)
+- [ ] Validator report exists for latest run. (evidence: `runtime/src/runner_v2/runner.py`)
+- [ ] `indices/*.json` parse OK. (evidence: `runtime/indexer.py`)
+
+## 8) FACT REQUESTS backlog
+
+- [ ] Vraag: welke host/port is canonical (localhost vs 127.0.0.1 vs ::1)?
+  - Command/file: `runtime/scripts/dev_start_api.sh`, `runtime/scripts/qa_full_system.sh`.
+  - Unlocks: consistent health checks.
+
+- [ ] Vraag: QA target pad is runtime of frozen snapshot?
+  - Command/file: `runtime/scripts/qa_suite_x.sh`, `runtime/scripts/qa_verify_inbox.sh`.
+  - Unlocks: accurate QA results.
+
+- [ ] Vraag: canonical runbook locatie?
+  - Command/file: `documentation/system_overview/DEV_WORKFLOW.md` vs `docs/REPO_MIGRATION_VERIFICATION.md`.
+  - Unlocks: doc single source of truth.
+
+- [ ] Vraag: status van `runtime/canonical/` (bestaat of niet)?
+  - Command/file: `runtime/api_server.py`, filesystem check. 
+  - Unlocks: canonical write policy clarity.
+
+- [ ] Vraag: expected run layouts (runner_v2 vs phase8/phase9)?
+  - Command/file: `runtime/src/runner_v2/run_layout_adapter.py`.
+  - Unlocks: indexer determinism.
+
+- [ ] Vraag: CrewAI version pin + model env vars (OPENAI_MODEL/LITELLM_MODEL)?
+  - Command/file: `runtime/src/mustikarasa_agents.py`, `runtime/requirements-ui.txt`.
+  - Unlocks: stable pipeline execution.
+
+- [ ] Vraag: API base path/host for UI proxy (localhost vs 127.0.0.1)?
+  - Command/file: `runtime/ui/vite.config.ts`.
+  - Unlocks: consistent UI/API connectivity.
+
+- [ ] Vraag: which docs are authoritative for QA? 
+  - Command/file: `documentation/system_overview/DEV_WORKFLOW.md`, `docs/REPO_MIGRATION_VERIFICATION.md`.
+  - Unlocks: avoid QA drift.
+
+## 9) Status log (append-only)
+
+- 2026-01-20 — MASTERPLAN_BIG_ROCKS.md updated to fact-first masterplan with blockers, contracts, and patch plan. (evidence: `documentation/system_overview/MASTERPLAN_BIG_ROCKS.md`)
+- 2026-01-20 — CI workflow allows runtime, forbids runtime state; API host canon 127.0.0.1; QA scripts no snapshot. (evidence: `.github/workflows/verify-repo.yml`, `runtime/scripts/dev_start_api.sh`, `runtime/scripts/qa_suite_x.sh`, `runtime/scripts/qa_verify_inbox.sh`, `documentation/system_overview/DEV_WORKFLOW.md`)
+- 2026-01-20 — Scope correction: reverted unintended edits to runner/pipeline files back to HEAD; Phase 1 fixes remain limited to workflow + scripts + docs.

--- a/documentation/system_overview/PROJECT_STATE_PACK.md
+++ b/documentation/system_overview/PROJECT_STATE_PACK.md
@@ -11,7 +11,7 @@
 - Excerpt registry is complete for all chapters with stable IDs/versions; chapter→excerpt alignment is complete for listed chapters.
 - Ingest artifacts with provenance exist for hoofdstuk_01 and hoofdstuk_02 under `runtime/data/ingest/chapters/`.
 - Review packs exist as derived artefacts under `runtime/proposals/<proposal_id>/review_pack/` (exposed in proposal API response).
-- Excerpt coverage validation is ACTIVE via `python3 runtime/scripts/validate_excerpt_coverage.py` and outputs `runtime/audit/coverage_report_latest.md`.
+- Excerpt coverage validation is ACTIVE via `runtime/.venv/bin/python runtime/scripts/validate_excerpt_coverage.py` and outputs `runtime/audit/coverage_report_latest.md`.
 - Proposal/closure review artefacts are standardized and human-reviewable, with batch consistency validated across P-001..P-004.
 - Milestone 2 (excerpt-level run orchestration) is DONE; per-chapter batch scripting is out of scope for M2.
 
@@ -60,16 +60,15 @@ Start API (recommended script):
 Start UI (recommended script):
 - `runtime/scripts/dev_start_ui.sh`
 
-Stop dev processes (ports 8000/5173/5174):
+Stop dev processes (ports 8010/5173/5174):
 - `runtime/scripts/dev_down.sh`
 
 Reindex (runtime root):
 - `runtime/scripts/reindex_runtime.sh`
-- `python3 runtime/indexer.py --base-path runtime`
+- `runtime/.venv/bin/python runtime/indexer.py --base-path runtime`
 
 Python note:
-- If `runtime/.venv` exists, activate it before running scripts.
-- Otherwise use `python3` for all commands and ensure dependencies are installed.
+- `runtime/.venv` (Python 3.11) is required for RunnerV2 + CrewAI.
 
 ## Current invariants (non-negotiable)
 - `runtime/canonical/` is read-only (no direct writes).
@@ -183,7 +182,7 @@ Indices:
 
 ### Excerpt coverage validation (as-built)
 
-- Excerpt coverage validation is runnable via `python3 runtime/scripts/validate_excerpt_coverage.py`.
+- Excerpt coverage validation is runnable via `runtime/.venv/bin/python runtime/scripts/validate_excerpt_coverage.py`.
 - Output artifact: `runtime/audit/coverage_report_latest.md` (derived; regenerable).
 
 ### As-built architecture documentation

--- a/documentation/system_overview/issues/ENV_VENV_CREWAI_MISMATCH.md
+++ b/documentation/system_overview/issues/ENV_VENV_CREWAI_MISMATCH.md
@@ -1,0 +1,74 @@
+# Clarify authoritative Python/venv for RunnerV2 + translation pipeline (CrewAI mismatch)
+
+## TL;DR
+
+* Repo docs + runtime scripts imply `runtime/.venv` is the intended runtime.
+* RunnerV2/QA/pipeline scripts run via PATH `python3` (no venv activation).
+* CrewAI is installed only in monorepo root `.venv` (Python 3.11), not in `runtime/.venv` (Python 3.14), causing
+  `ModuleNotFoundError`.
+
+---
+
+## What we observed (evidence, fact-first)
+
+### 1) Strong signals `runtime/.venv` is intended
+
+* `runtime/scripts/dev_start_api.sh` activates `runtime/.venv` and runs `python -m uvicorn`
+  **Evidence:** `runtime/scripts/dev_start_api.sh:7–13`, `28`
+* `runtime/scripts/reindex_runtime.sh` activates `runtime/.venv` and runs `python indexer.py`
+  **Evidence:** `runtime/scripts/reindex_runtime.sh:6–16`
+* Docs explicitly prefer `runtime/.venv`
+  **Evidence:** `docs/REPO_MIGRATION_VERIFICATION.md:10` (“venv in `runtime/.venv` preferred”), `118` (“Activate venv … in `runtime/.venv`”)
+
+### 2) Scripts that bypass `runtime/.venv` (use PATH `python3`)
+
+* RunnerV2 CLI uses shebang `/usr/bin/env python3` and does not activate a venv
+  **Evidence:** `runtime/scripts/mustika_run_excerpt.py:1`
+* QA suite calls `python3` directly for pipeline + runner smoke
+  **Evidence:** `runtime/scripts/qa_suite_x.sh:73–74`
+* Full-system QA uses `python3` directly (no venv activation)
+  **Evidence:** `runtime/scripts/qa_full_system.sh:28–29`, `72–73`
+
+### 3) CrewAI is not declared for runtime, but runtime code expects it
+
+* `runtime/requirements-ui.txt` does **not** list `crewai`
+  **Evidence:** `runtime/requirements-ui.txt`
+* `runtime/src/runner_v2/llm_client.py` imports `crewai` and raises “CrewAI not installed…”
+  **Evidence:** `runtime/src/runner_v2/llm_client.py:25–32`
+
+### 4) Measured interpreter mismatch (reproducible on this machine)
+
+* `runtime/.venv` python (3.14.2): `import crewai` **FAIL**
+* PATH python3 (brew, 3.14.2): `import crewai` **FAIL**
+* monorepo root `.venv` python (3.11.14): `import crewai` **OK** (crewai 1.7.2)
+
+---
+
+## Impact / symptom
+
+RunnerV2 via `runtime/scripts/mustika_run_excerpt.py` fails when the pipeline imports CrewAI-dependent code:
+`ModuleNotFoundError: No module named 'crewai'`
+
+---
+
+## Questions for maintainers (seeking authoritative clarification; no fix proposed yet)
+
+1. Which venv/interpreter is authoritative for:
+
+* RunnerV2 (`runtime/scripts/mustika_run_excerpt.py`)
+* `test_multi_agent_fidelity.py` pipeline
+* `qa_suite_x.sh` and `qa_full_system.sh`
+
+Is it `runtime/.venv`, monorepo-root `.venv`, or something else?
+
+2. Where should CrewAI be installed (runtime venv vs root venv), and which Python version is supported?
+
+3. Is there a source-of-truth doc or config (runbook, lockfile, Make target, CI) that explicitly pins the intended interpreter/venv for these scripts?
+
+---
+
+## Context
+
+* Repo currently has untracked copies of `test_multi_agent_fidelity.py` under `runtime/` and repo root (created during local debugging), but the core mismatch exists regardless: scripts + docs are inconsistent about which Python is used.
+
+Thanks — once the intended environment is confirmed, we can align entrypoints/QA or dependency declarations accordingly.

--- a/documentation/system_overview/issues/ENV_VENV_CREWAI_MISMATCH.md
+++ b/documentation/system_overview/issues/ENV_VENV_CREWAI_MISMATCH.md
@@ -31,7 +31,7 @@
 
 ### 3) CrewAI is not declared for runtime, but runtime code expects it
 
-* `runtime/requirements-ui.txt` does **not** list `crewai`
+* `runtime/requirements-ui.txt` now pins `crewai==1.8.1`
   **Evidence:** `runtime/requirements-ui.txt`
 * `runtime/src/runner_v2/llm_client.py` imports `crewai` and raises “CrewAI not installed…”
   **Evidence:** `runtime/src/runner_v2/llm_client.py:25–32`
@@ -70,5 +70,7 @@ Is it `runtime/.venv`, monorepo-root `.venv`, or something else?
 ## Context
 
 * Repo currently has untracked copies of `test_multi_agent_fidelity.py` under `runtime/` and repo root (created during local debugging), but the core mismatch exists regardless: scripts + docs are inconsistent about which Python is used.
+
+2026-01-20: Updated to reflect current dependency declaration in `runtime/requirements-ui.txt`.
 
 Thanks — once the intended environment is confirmed, we can align entrypoints/QA or dependency declarations accordingly.

--- a/documentation/system_overview/issues/README.md
+++ b/documentation/system_overview/issues/README.md
@@ -1,0 +1,5 @@
+Issues snapshots / evidence dumps (filesystem-first).
+Link to masterplan: documentation/system_overview/MASTERPLAN_BIG_ROCKS.md.
+No secrets or tokens; redact before committing.
+Naming convention: YYYYMMDD_slug.md.
+Keep entries short, fact-first, and reproducible.

--- a/runtime/README_UI.md
+++ b/runtime/README_UI.md
@@ -1,5 +1,7 @@
 # Mustika Rasa Human UI - Setup & Usage
 
+Authoritative environment setup: `documentation/system_overview/ENVIRONMENT.md` (this file is UI-specific).
+
 ## Overview
 
 De Human UI is een local-first interface voor het beheren van de Mustika Rasa governance workflow. Het biedt een MVP met:

--- a/runtime/README_UI.md
+++ b/runtime/README_UI.md
@@ -18,7 +18,7 @@ Zie `docs/DEV_WORKFLOW.md` voor de volledige dev-flow.
 TL;DR:
 ```bash
 cd /path/to/repo
-source .venv/bin/activate   # optional if scripts handle venv
+source .venv/bin/activate   # required (Python 3.11, CrewAI)
 ./scripts/dev_up.sh
 ```
 Open `http://localhost:5173` (of `http://localhost:5174` als 5173 bezet is).
@@ -31,12 +31,12 @@ Docs:
 
 ### Backend (FastAPI)
 
-1. Installeer dependencies:
+1. Installeer dependencies (includes CrewAI):
 ```bash
 pip install -r requirements-ui.txt
 ```
 
-2. Start de API server:
+2. Start de API server (runtime venv required):
 ```bash
 python api_server.py
 ```
@@ -80,7 +80,7 @@ De UI is beschikbaar op http://localhost:5173
 
 2. Genereer indices:
    - Via de UI: klik op "Reindex" in het Dashboard
-   - Via CLI: `python indexer.py`
+   - Via CLI: `./scripts/reindex_runtime.sh`
 
 3. Start beide servers (backend en frontend)
 

--- a/runtime/requirements-ui.txt
+++ b/runtime/requirements-ui.txt
@@ -4,3 +4,6 @@
 fastapi>=0.104.0
 uvicorn[standard]>=0.24.0
 pydantic>=2.0.0
+
+# Translation pipeline deps
+crewai==1.8.1

--- a/runtime/scripts/dev_start_api.sh
+++ b/runtime/scripts/dev_start_api.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+API_HOST="${API_HOST:-127.0.0.1}"
 API_PORT="${API_PORT:-8010}"
 
 if [[ -f "$ROOT/.venv/bin/activate" ]]; then
@@ -24,13 +25,12 @@ if command -v lsof >/dev/null 2>&1; then
   fi
 fi
 
-echo "Starting API on http://localhost:${API_PORT} ..."
-nohup python -m uvicorn api_server:app --host ::1 --port "$API_PORT" \
-  > "$ROOT/audit/api_server.log" 2>&1 &
+echo "Starting API on http://${API_HOST}:${API_PORT} ..."
+nohup python -m uvicorn api_server:app --host "$API_HOST" --port "$API_PORT" > "$ROOT/audit/api_server.log" 2>&1 &
 echo $! > "$ROOT/audit/api_server.pid"
 echo "API PID: $(cat "$ROOT/audit/api_server.pid")"
 
 if command -v curl >/dev/null 2>&1; then
-  health="$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${API_PORT}/health" || true)"
-  echo "Health check: http://localhost:${API_PORT}/health => ${health}"
+  health="$(curl -s -o /dev/null -w "%{http_code}" "http://${API_HOST}:${API_PORT}/health" || true)"
+  echo "Health check: http://${API_HOST}:${API_PORT}/health => ${health}"
 fi

--- a/runtime/scripts/mustika_run_excerpt.py
+++ b/runtime/scripts/mustika_run_excerpt.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+
+# --- venv guard (mustika_run_excerpt) ---
+import os
+if not os.environ.get('VIRTUAL_ENV'):
+    raise SystemExit(
+        'ERROR: No active venv. Activate runtime/.venv first: '
+        'cd runtime && source .venv/bin/activate'
+    )
+
 """
 CLI entrypoint for Runner V2 - Phase-6 Excerpt-Aware Runner
 

--- a/runtime/scripts/qa_contract_test.py
+++ b/runtime/scripts/qa_contract_test.py
@@ -4,6 +4,15 @@ import sys
 from pathlib import Path
 import tempfile
 
+
+# --- venv guard (qa_contract_test) ---
+import os
+if not os.environ.get('VIRTUAL_ENV'):
+    raise SystemExit(
+        'ERROR: No active venv. Activate runtime/.venv first: '
+        'cd runtime && source .venv/bin/activate'
+    )
+
 RUNTIME_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(RUNTIME_ROOT))
 

--- a/runtime/scripts/qa_full_system.sh
+++ b/runtime/scripts/qa_full_system.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure runtime venv is active (avoid PATH python mismatches)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ -f "$ROOT/.venv/bin/activate" ]; then
+  # shellcheck disable=SC1090
+  source "$ROOT/.venv/bin/activate"
+else
+  echo "ERROR: missing runtime/.venv. Create it under runtime/.venv (Python 3.11) and install deps."
+  exit 1
+fi
+
 set -u
 
 BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"

--- a/runtime/scripts/qa_suite_x.sh
+++ b/runtime/scripts/qa_suite_x.sh
@@ -13,7 +13,13 @@ fi
 
 set -uo pipefail
 
-RUNTIME_ROOT="/Users/vwvd/Millway/AI-folder/Crew-AI/cursor/codex cli project repo copy"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$RUNTIME_ROOT/.." && pwd)"
+if [[ ! -f "${RUNTIME_ROOT}/api_server.py" || ! -f "${RUNTIME_ROOT}/indexer.py" ]]; then
+  echo "ERROR: runtime root missing api_server.py or indexer.py: ${RUNTIME_ROOT}" >&2
+  exit 1
+fi
 QA_ROOT="${RUNTIME_ROOT}/audit/qa"
 TS="$(date +%Y%m%dT%H%M%S)"
 RUN_DIR="${QA_ROOT}/runs/${TS}"
@@ -68,18 +74,18 @@ else
 fi
 
 ## L0 checks (contracts / entrypoints)
-run_test "L0_OCR_CONTRACTS" "rg -n \"page_sources/ocr_txt|page_sources/ocr_tsv|OCR Correction Contract\" /Users/vwvd/Millway/AI-folder/Crew-AI/mustika-rasa-clean/documentation/operator"
-run_test "L0_OCR_CORRECTION_CONTRACT" "rg -n \"page_ocr_corrected|manifests/<page_id>.json\" /Users/vwvd/Millway/AI-folder/Crew-AI/mustika-rasa-clean/documentation/operator/OCR_CORRECTION_CONTRACT.md"
-run_test "L0_DEFINITIVE_SOURCE_CONTRACT" "rg -n \"definitive_source|builds/<BUILD_ID>/source_nl.txt\" /Users/vwvd/Millway/AI-folder/Crew-AI/mustika-rasa-clean/documentation/operator/DEFINITIVE_SOURCE_BUILD_CONTRACT.md"
-run_test "L0_TRANSLATION_ENTRYPOINTS" "rg -n \"run_pipeline|Translation → Readability → Fidelity\" test_multi_agent_fidelity.py mustikarasa_codex_cli.py"
-run_test "L0_RUNNER_V2_CONTRACT" "rg -n \"create_run_directory|outputs/final.txt|output_contract_checks.txt\" src/runner_v2/runner.py"
-run_test "L0_VALIDATOR_CONTRACT" "rg -n \"overall_status|CHECK_RESULTS|PASS|FAIL\" sandbox/tools/phase8_output_contract_validator.sh"
-run_test "L0_INDEXER_RULES" "rg -n \"validator_fail|blocking_gate|challenger_issues|proposal_open|required_closure\" indexer.py"
-run_test "L0_REVIEW_PACK_API" "rg -n \"review_pack\" api_server.py"
-run_test "L0_PROPOSAL_SCHEMA" "rg -n \"proposal.md|status.json|required_closure.json\" indexer.py"
-run_test "L0_CLOSURE_SCHEMA" "rg -n \"class ClosureCreate|create_closure\" api_server.py"
-run_test "L0_AUDIT_LOGS" "rg -n \"ensure_audit_log\" api_server.py"
-run_test "L0_MIGRATION_SCRIPT" "rg -n \"DRY_RUN|migration_reports\" scripts/migrate_to_clean_repo.sh"
+run_test "L0_OCR_CONTRACTS" "rg -n 'page_sources/ocr_txt|page_sources/ocr_tsv|OCR Correction Contract' \"${REPO_ROOT}/documentation/operator\""
+run_test "L0_OCR_CORRECTION_CONTRACT" "rg -n 'page_ocr_corrected|manifests/<page_id>.json' \"${REPO_ROOT}/documentation/operator/OCR_CORRECTION_CONTRACT.md\""
+run_test "L0_DEFINITIVE_SOURCE_CONTRACT" "rg -n 'definitive_source|builds/<BUILD_ID>/source_nl.txt' \"${REPO_ROOT}/documentation/operator/DEFINITIVE_SOURCE_BUILD_CONTRACT.md\""
+run_test "L0_TRANSLATION_ENTRYPOINTS" "rg -n 'run_pipeline|Translation → Readability → Fidelity' test_multi_agent_fidelity.py mustikarasa_codex_cli.py"
+run_test "L0_RUNNER_V2_CONTRACT" "rg -n 'create_run_directory|outputs/final.txt|output_contract_checks.txt' src/runner_v2/runner.py"
+run_test "L0_VALIDATOR_CONTRACT" "rg -n 'overall_status|CHECK_RESULTS|PASS|FAIL' sandbox/tools/phase8_output_contract_validator.sh"
+run_test "L0_INDEXER_RULES" "rg -n 'validator_fail|blocking_gate|challenger_issues|proposal_open|required_closure' indexer.py"
+run_test "L0_REVIEW_PACK_API" "rg -n 'review_pack' api_server.py"
+run_test "L0_PROPOSAL_SCHEMA" "rg -n 'proposal.md|status.json|required_closure.json' indexer.py"
+run_test "L0_CLOSURE_SCHEMA" "rg -n 'class ClosureCreate|create_closure' api_server.py"
+run_test "L0_AUDIT_LOGS" "rg -n 'ensure_audit_log' api_server.py"
+run_test "L0_MIGRATION_SCRIPT" "rg -n 'DRY_RUN|migration_reports' scripts/migrate_to_clean_repo.sh"
 
 ## L1 checks (smoke)
 run_test "L1_TRANSLATION_PIPELINE" "printf \"EN test\" > /tmp/qa_en.txt && printf \"NL test\" > /tmp/qa_nl.txt && python3 test_multi_agent_fidelity.py --english /tmp/qa_en.txt --rough-nl /tmp/qa_nl.txt"
@@ -90,8 +96,8 @@ run_test "L1_VALIDATOR_FAIL_SIM" "mkdir -p /tmp/qa_run/eval /tmp/qa_run/outputs 
 skip_test "L1_INDEXER_INBOX_SIM" "SKIP: would require manual run bundle creation under runs/ (not allowed)"
 
 if [[ "${API_UP}" == "yes" ]]; then
-  run_test "L1_REVIEW_PACK_API" "mkdir -p proposals/P-TEST-REVIEW/review_pack && printf \"dummy\" > proposals/P-TEST-REVIEW/review_pack/readme.txt && curl -s http://127.0.0.1:8010/proposals/P-TEST-REVIEW | python3 -m json.tool | rg -n \"review_pack\""
-  run_test "L1_PROPOSAL_API" "mkdir -p proposals/P-TEST && printf \"# P-TEST\\nbody\" > proposals/P-TEST/proposal.md && printf '{ \"status\": \"open\", \"severity\": \"info\" }' > proposals/P-TEST/status.json && curl -s http://127.0.0.1:8010/proposals/P-TEST | python3 -m json.tool | rg -n \"proposal_md|status\""
+  run_test "L1_REVIEW_PACK_API" "mkdir -p proposals/P-TEST-REVIEW/review_pack && printf \"dummy\" > proposals/P-TEST-REVIEW/review_pack/readme.txt && curl -s http://127.0.0.1:8010/proposals/P-TEST-REVIEW | python3 -m json.tool | rg -n 'review_pack'"
+  run_test "L1_PROPOSAL_API" "mkdir -p proposals/P-TEST && printf \"# P-TEST\\nbody\" > proposals/P-TEST/proposal.md && printf '{ \"status\": \"open\", \"severity\": \"info\" }' > proposals/P-TEST/status.json && curl -s http://127.0.0.1:8010/proposals/P-TEST | python3 -m json.tool | rg -n 'proposal_md|status'"
   run_test "L1_CLOSURE_API" "mkdir -p proposals/P-TEST-CLOSE && printf '{ \"status\": \"open\", \"severity\": \"info\" }' > proposals/P-TEST-CLOSE/status.json && curl -s -X POST http://127.0.0.1:8010/closures -H 'Content-Type: application/json' -d '{\"proposal_id\":\"P-TEST-CLOSE\",\"run_id\":\"RUN_QA_SUITE_X\",\"decision_type\":\"qa_suite_x\",\"rationale\":\"QA suite X closure rationale\",\"evidence_paths\":[\"proposals/P-TEST-CLOSE/status.json\"],\"sign_off\":true,\"created_by\":\"qa\"}'"
   run_test "L1_AUDIT_REINDEX" "curl -s -X POST http://127.0.0.1:8010/reindex | python3 -m json.tool | rg -n \"ok|generated_files\""
 else

--- a/runtime/scripts/qa_suite_x.sh
+++ b/runtime/scripts/qa_suite_x.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure runtime venv is active (avoid PATH python mismatches)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ -f "$ROOT/.venv/bin/activate" ]; then
+  # shellcheck disable=SC1090
+  source "$ROOT/.venv/bin/activate"
+else
+  echo "ERROR: missing runtime/.venv. Create it under runtime/.venv (Python 3.11) and install deps."
+  exit 1
+fi
+
 set -uo pipefail
 
 RUNTIME_ROOT="/Users/vwvd/Millway/AI-folder/Crew-AI/cursor/codex cli project repo copy"

--- a/runtime/scripts/qa_verify_inbox.sh
+++ b/runtime/scripts/qa_verify_inbox.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+# Ensure runtime venv is active (avoid PATH python mismatches)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ -f "$ROOT/.venv/bin/activate" ]; then
+  # shellcheck disable=SC1090
+  source "$ROOT/.venv/bin/activate"
+else
+  echo "ERROR: missing runtime/.venv. Create it under runtime/.venv (Python 3.11) and install deps."
+  exit 1
+fi
+
 set -euo pipefail
 
 RUNTIME_ROOT="/Users/vwvd/Millway/AI-folder/Crew-AI/cursor/codex cli project repo copy"

--- a/runtime/scripts/qa_verify_inbox.sh
+++ b/runtime/scripts/qa_verify_inbox.sh
@@ -11,7 +11,12 @@ fi
 
 set -euo pipefail
 
-RUNTIME_ROOT="/Users/vwvd/Millway/AI-folder/Crew-AI/cursor/codex cli project repo copy"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ ! -f "${RUNTIME_ROOT}/api_server.py" || ! -f "${RUNTIME_ROOT}/indexer.py" ]]; then
+  echo "ERROR: runtime root missing api_server.py or indexer.py: ${RUNTIME_ROOT}" >&2
+  exit 1
+fi
 API_URL="http://127.0.0.1:8010"
 
 cd "${RUNTIME_ROOT}"

--- a/runtime/src/mustikarasa_agents.py
+++ b/runtime/src/mustikarasa_agents.py
@@ -1,0 +1,54 @@
+"""
+Minimal CrewAI agent definitions for the RunnerV2 translation pipeline.
+"""
+
+from __future__ import annotations
+
+import os
+
+from crewai import Agent, LLM
+
+
+def _build_llm() -> LLM:
+    model = os.getenv("LITELLM_MODEL") or os.getenv("OPENAI_MODEL")
+    if not model:
+        raise RuntimeError(
+            "Missing model configuration: set LITELLM_MODEL or OPENAI_MODEL."
+        )
+
+    kwargs = {}
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        kwargs["api_key"] = api_key
+    base_url = os.getenv("LITELLM_BASE_URL") or os.getenv("OPENAI_BASE_URL")
+    if base_url:
+        kwargs["base_url"] = base_url
+
+    return LLM(model=model, **kwargs)
+
+
+_LLM = _build_llm()
+
+translation_quality_agent = Agent(
+    role="Translation Quality Agent",
+    goal="Improve rough Dutch translations while preserving meaning.",
+    backstory="A careful editor focused on fidelity and grammar.",
+    llm=_LLM,
+    verbose=False,
+)
+
+readability_editor = Agent(
+    role="Readability Editor",
+    goal="Polish Dutch text for clarity and natural flow.",
+    backstory="A stylist who improves readability without changing meaning.",
+    llm=_LLM,
+    verbose=False,
+)
+
+fidelity_agent = Agent(
+    role="Fidelity Agent",
+    goal="Ensure the Dutch output remains faithful to the English source.",
+    backstory="A final checker who flags meaning drift and ambiguity.",
+    llm=_LLM,
+    verbose=False,
+)


### PR DESCRIPTION
## Summary
What changes are introduced?

## Evidence
List relevant file paths and any run/audit artefacts.

## Invariant checklist (AS_BUILT_ARCH.md)
- [ ] Filesystem-first preserved (no moving runtime truth into GitHub)
- [ ] No canonical auto-promotion / no forbidden writes
- [ ] Page sources remain read-only for agents
- [ ] runtime/ and indices/ handling unchanged unless explicitly decided

## Verification
- [ ] I followed documentation/operator/RUNBOOK.md where relevant
- [ ] I did not commit runtime-generated state (runtime/, indices/)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns environment, CI, and scripts around a canonical runtime and venv, and documents the golden path.
> 
> - **CI**: Update `.github/workflows/verify-repo.yml` to allow tracked `runtime/` code but block tracked runtime state (`runtime/{indices,runs,audit,proposals,closures}/`, `runtime/.venv*`) and top-level `indices/`.
> - **Environment/docs**: Add authoritative `documentation/system_overview/ENVIRONMENT.md`; update `DEV_WORKFLOW.md`, `RUNBOOK.md`, `REPO_MIGRATION_VERIFICATION.md`, `PROJECT_STATE_PACK.md`, `INVENTORY.md`, and UI README to require Python 3.11 `runtime/.venv`, use `127.0.0.1:8010`, and prefer `runtime/scripts/*` commands.
> - **Scripts**: `runtime/scripts/dev_start_api.sh` binds to `127.0.0.1` (configurable via `API_HOST`), sets `PYTHONPATH`, and enforces venv; QA scripts (`qa_full_system.sh`, `qa_suite_x.sh`, `qa_verify_inbox.sh`) now activate `runtime/.venv`, drop hardcoded snapshot paths, and add sanity checks; `mustika_run_excerpt.py` adds a venv guard; add `qa_contract_test.py`.
> - **Dependencies/agents**: Pin `crewai==1.8.1` in `runtime/requirements-ui.txt`; add minimal CrewAI agents in `runtime/src/mustikarasa_agents.py` (used by RunnerV2 pipeline).
> - **Planning**: Add `MASTERPLAN_BIG_ROCKS.md` and issue snapshots under `documentation/system_overview/issues/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76272db810d4ae793a9b3f9e5befde22196e8ab6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->